### PR TITLE
changed the slash por the fetch end point

### DIFF
--- a/src/services/employees.service.ts
+++ b/src/services/employees.service.ts
@@ -5,10 +5,10 @@ export async function getAllEmployees(): Promise<Employee[]> {
     let response;
     let data: Employee[] = [];
     try {
-        response = await fetch(`${API_URL}employees`);
+        response = await fetch(`${API_URL}/employees`);
         data = await response.json();
     } catch (error) {
-        throw new Error(JSON.stringify(error));
+        console.log(error);
     }
    
     if (!response) {


### PR DESCRIPTION
As far as I've seen, it's better to let the '/' to put it manually when consumed in an api to avoid confusions:

I changed this:
`${API_URL}employees`

for this:
`${API_URL}/employees`

Hence I also have my .env like this:
REACT_APP_API_URL="http://localhost:4000"